### PR TITLE
Minor bug fix on timeline component

### DIFF
--- a/src/components/map/itemTimeline/helper/index.ts
+++ b/src/components/map/itemTimeline/helper/index.ts
@@ -21,7 +21,7 @@ export function parseItems(vizItems: STACItem[]) {
   return vizItems
     .map(item => ({
       id: item.id,
-      date: moment.utc(item.properties.datetime).toDate(),
+      date: moment.utc(item.properties.start_datetime).toDate(),
     }))
     .sort((a, b) => a.date.getTime() - b.date.getTime());
 }

--- a/src/components/map/itemTimeline/index.tsx
+++ b/src/components/map/itemTimeline/index.tsx
@@ -37,7 +37,7 @@ import './index.css';
 interface VizItemTimelineProps {
   vizItems: STACItem[];
   onVizItemSelect: (id: string) => void;
-  activeItem?: STACItem | null;
+  activeItemId?: string | null;
   onVizItemHover?: (id: string) => void;
   title?: string;
 }
@@ -47,7 +47,7 @@ interface VizItemTimelineProps {
 export const VizItemTimeline = ({
   vizItems = [],
   onVizItemSelect = () => {},
-  activeItem = null,
+  activeItemId = null,
   onVizItemHover = () => {},
   title = 'Timeline',
 }: VizItemTimelineProps): JSX.Element => {
@@ -61,7 +61,10 @@ export const VizItemTimeline = ({
   const parsedItems = useMemo(() => parseItems(vizItems), [vizItems]);
   const dates = useMemo(() => parsedItems.map(item => item.date), [parsedItems]);
 
-  const [activeIndex, setActiveIndex] = useState(activeItem ? parsedItems.findIndex(item => item.id === activeItem.id) : 0);
+  // get the activeItemIndex based on the activeItemId prop
+  const activeItemIndex = parsedItems.findIndex(item => item.id === activeItemId);
+  const [activeIndex, setActiveIndex] = useState(activeItemIndex >= 0 ? activeItemIndex : 0);
+
   const activeDate = dates[activeIndex];
   const activeDateRef = useRef(activeDate);
 


### PR DESCRIPTION
1. Take activeItemId as prop instead of the entire stack item
2. Handle cases when activeItemId doesn't match with existing items
3. use start_datetime as the property to load points on the timeline