### PR TITLE
feat: DataFactory ABC used as props to Dashboard instead of DataTree

### DIFF
--- a/src/components/ui/card/stacItemInfoCard.tsx
+++ b/src/components/ui/card/stacItemInfoCard.tsx
@@ -114,9 +114,9 @@ export function StacItemInfoCard({
     setId(id);
     setCollection(collection);
 
-    let coordinates: number[] = stacItem.geometry.coordinates[0][0];
-    setLon(coordinates[0]);
-    setLat(coordinates[1]);
+    let coordinates: string[] = stacItem.geometry.coordinates[0][0];
+    setLon(Number(coordinates[0]));
+    setLat(Number(coordinates[1]));
 
     let VMIN = 0;
     let VMAX = 0.4;

--- a/src/core/dataFactory.tsx
+++ b/src/core/dataFactory.tsx
@@ -1,0 +1,30 @@
+import { VizItem } from '../dataModel';
+/**
+ * This is the bare minimum that the dashboard application will need to function.
+ * During the concrete implementation of this base class, add in the necessary functions
+ * as per the useCase.
+ *
+ * Note: VizItem is synonym used for STACItem
+ */
+export abstract class DataFactory {
+  /**
+   * Adds a visualization item to the data factory internal dataTree implementation.
+   * @param vizItem The visualization item to add.
+   * The implementation is expected to have O(1) complexity.
+   */
+  abstract addVizItem(vizItem: VizItem): void;
+  /**
+   * Gets the VizItems. The VizItems will be used to plot the markers.
+   * @returns VizItem[] - araray of vizItems that is needed to plot the markers.
+   * The implementation is expected to have O(k) complexity. where 'k' is the number of markers.
+   */
+  abstract getVizItemForMarker(): VizItem[];
+  /**
+   * Gets the VizItems. The VizItems will be used for Vizualization when clicked on the marker.
+   * @param key Representing the vizItem.id of the clicked marker
+   * @returns VizItem[] - array of vizItems that is needed to plot the markers.
+   * Note: If there is only one layer needed when marker is clicked, just return [vizItem]
+   * The implementation is expected to have O(1) complexity.
+   */
+  abstract getVizItemsOnMarkerClicked(key: string): VizItem[];
+}

--- a/src/dataModel/index.ts
+++ b/src/dataModel/index.ts
@@ -20,3 +20,5 @@ export type {
   SAM,
   Target,
 };
+
+export interface VizItem extends STACItem {}

--- a/src/dataModel/sams.ts
+++ b/src/dataModel/sams.ts
@@ -5,8 +5,7 @@ import { STACItem, DateTime, Lon, Lat } from './core';
 	- are data_collections/images over 80x80 km in 2 mins.
 	- are collected by PMA (Pointing Mirror Assembly) of OCO3
  */
-
-export type SAM = STACItem; // This is the smallest working unit of data.
+export interface SAM extends STACItem {}
 
 export interface Target {
   id: string;  //Format: <data-type>_<target_id>_<datetime>_<filter-status>_<ghg-type>. e.g. "oco3-co2_volcano0010_2025-03-30T232216Z_unfiltered_xco2"

--- a/src/exampleDataFactory/index.ts
+++ b/src/exampleDataFactory/index.ts
@@ -1,0 +1,45 @@
+import { DataFactory } from '../core/dataFactory';
+import { VizItem } from '../dataModel';
+
+export class ExampleDataFactory extends DataFactory {
+  private static instance: ExampleDataFactory;
+  private constructor() {
+    super();
+    this.dataTree = {};
+  }
+  /**
+   * The dataTree refers to the STACItems(/vizItems), structured in certain way
+   * inorder to fullfill the application needs (refers. data Interfaces).
+   * Example 1: Here, its simple map between STACItem.id and STACItem.
+   * Example 2: Complex application needs might ask for somekind of complex dataTree
+   * - representing one to many relationships - hence requiring n-tree instead of simple dictionary.
+   */
+  private dataTree: { [itemId: string]: VizItem };
+
+  public static getInstance(): ExampleDataFactory {
+    if (!ExampleDataFactory.instance) {
+      ExampleDataFactory.instance = new ExampleDataFactory();
+    }
+    return ExampleDataFactory.instance;
+  }
+
+  getVizItemForMarker(): VizItem[] {
+    return Object.values(this.dataTree);
+  }
+
+  getVizItemsOnMarkerClicked(key: string): VizItem[] {
+    if (key in this.dataTree) {
+      return [this.dataTree[key]];
+    }
+    return [];
+  }
+
+  getVizItemsOnLayerClicked(key: string): VizItem[] {
+    return Object.values(this.dataTree).slice(0, 5);
+  }
+
+  addVizItem(vizItem: VizItem): void {
+    let key = vizItem.id;
+    this.dataTree[key] = vizItem;
+  }
+}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -20,12 +20,11 @@ import {
   FilterByDate,
   VizItemAnimation,
   VisualizationItemCard,
-  VizItemTimeline
+  VizItemTimeline,
 } from '../../components/index.js';
 
-import { STACItem } from '../../dataModel';
-
-interface VizItem extends STACItem {}
+import { VizItem } from '../../dataModel';
+import { DataFactory } from '../../core/dataFactory';
 
 const TITLE: string = 'Interface Template';
 const DESCRIPTION: string = `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book`;
@@ -38,19 +37,8 @@ const HorizontalLayout = styled.div`
   margin: 12px;
 `;
 
-interface VizItemDict {
-  [key: string]: VizItem;
-}
-
 interface DashboardProps {
-  /**
-   * The dataTree refers to the STACItems(/vizItems), structured in certain way
-   * inorder to fullfill the application needs (refers. data Interfaces).
-   * Example 1: Here, its simple map between STACItem.id and STACItem.
-   * Example 2: Complex application needs might ask for somekind of complex dataTree
-   * - representing one to many relationships - hence requiring n-tree instead of simple dictionary.
-   */
-  dataTree: React.MutableRefObject<VizItemDict | null>;
+  dataFactory: React.MutableRefObject<DataFactory | null>;
   zoomLocation: number[];
   setZoomLocation: React.Dispatch<React.SetStateAction<number[]>>;
   zoomLevel: number | null;
@@ -59,7 +47,7 @@ interface DashboardProps {
 }
 
 export function Dashboard({
-  dataTree,
+  dataFactory,
   zoomLocation,
   setZoomLocation,
   zoomLevel,
@@ -67,12 +55,13 @@ export function Dashboard({
   loadingData,
 }: DashboardProps) {
   // states for data
-  const [vizItemsDict, setVizItemsDict] = useState<VizItemDict>({}); // store all available visualization items
   const [selectedVizItems, setSelectedVizItems] = useState<VizItem[]>([]); // all visualization items for the selected region (marker)
   const [hoveredVizLayerId, setHoveredVizLayerId] = useState<string>(''); // vizItem_id of the visualization item which was hovered over
   const [filteredVizItems, setFilteredVizItems] = useState<VizItem[]>([]); // visualization items for the selected region with the filter applied
 
-  const [vizItemsForAnimation, setVizItemsForAnimation] = useState<VizItem[]>([]); // list of subdaily_visualization_item used for animation
+  const [vizItemsForAnimation, setVizItemsForAnimation] = useState<VizItem[]>(
+    []
+  ); // list of subdaily_visualization_item used for animation
   const [visualizationLayers, setVisualizationLayers] = useState<VizItem[]>([]);
 
   //color map
@@ -87,12 +76,14 @@ export function Dashboard({
   // handler functions
   const handleSelectedVizItem = (vizItemId: string) => {
     if (!vizItemId) return;
-    let vizItem = vizItemsDict[vizItemId];
+    if (!dataFactory) return;
+    let vizItems =
+      dataFactory.current?.getVizItemsOnMarkerClicked(vizItemId) || [];
 
-    setVisualizationLayers([vizItem]);
+    setVisualizationLayers(vizItems);
     let location = [
-      Number(vizItem.geometry.coordinates[0][0][0]),
-      Number(vizItem.geometry.coordinates[0][0][1]),
+      Number(vizItems[0]?.geometry.coordinates[0][0][0]),
+      Number(vizItems[0]?.geometry.coordinates[0][0][1]),
     ];
     setZoomLocation(location);
     setZoomLevel(null); // take the default zoom level
@@ -101,10 +92,11 @@ export function Dashboard({
 
   const handleSelectedVizLayer = (vizItemId: string) => {
     if (!vizItemId) return;
-    let vizItem = vizItemsDict[vizItemId];
+    let vizItems =
+      dataFactory.current?.getVizItemsOnMarkerClicked(vizItemId) || [];
     let location = [
-      Number(vizItem.geometry.coordinates[0][0][0]),
-      Number(vizItem.geometry.coordinates[0][0][1]),
+      Number(vizItems[0]?.geometry.coordinates[0][0][0]),
+      Number(vizItems[0]?.geometry.coordinates[0][0][1]),
     ];
     setZoomLocation(location);
     handleSelectedVizItemSearch(vizItemId);
@@ -122,10 +114,11 @@ export function Dashboard({
   const handleSelectedVizItemSearch = (vizItemId: string) => {
     // will focus on the visualization item along with its visualization item metadata card
     // will react to update the metadata on the sidedrawer
-    if (!vizItemsDict || !vizItemId) return;
-    const vizItem = vizItemsDict[vizItemId];
-    const location = vizItem?.geometry?.coordinates[0][0];
-    setSelectedVizItems([vizItem]);
+    if (!vizItemId) return;
+    const vizItems =
+      dataFactory.current?.getVizItemsOnMarkerClicked(vizItemId) || [];
+    const location = vizItems[0]?.geometry?.coordinates[0][0];
+    setSelectedVizItems(vizItems);
     setOpenDrawer(true);
     setZoomLocation(location.map((coord) => Number(coord)));
     setZoomLevel(null); // take the default zoom level
@@ -133,8 +126,9 @@ export function Dashboard({
   };
 
   const handleResetHome = () => {
+    let vizItemdForMarker = dataFactory.current?.getVizItemForMarker() || [];
     setHoveredVizLayerId('');
-    setFilteredVizItems(selectedVizItems);
+    setSelectedVizItems(vizItemdForMarker);
     setVizItemsForAnimation([]);
     setOpenDrawer(false);
     setZoomLevel(4);
@@ -143,11 +137,10 @@ export function Dashboard({
 
   // Component Effects
   useEffect(() => {
-    if (!dataTree.current) return;
+    if (!dataFactory.current) return;
 
     // Mocked data initialization for the application.
-    setVizItemsDict(dataTree.current);
-    setSelectedVizItems(Object.values(dataTree.current));
+    setSelectedVizItems(dataFactory.current?.getVizItemForMarker() || []);
 
     // also few extra things for the application state. We can receive it from collection json.
     const VMIN = 0;
@@ -157,7 +150,7 @@ export function Dashboard({
     setVMAX(VMAX);
     setColormap(colormap);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataTree.current]);
+  }, [dataFactory.current]);
 
   // JSX
   return (
@@ -260,7 +253,7 @@ export function Dashboard({
       </div>
       {VMAX && (
         <ConfigurableColorBar
-          id ='configurable-color-bar'
+          id='configurable-color-bar'
           VMAXLimit={100}
           VMINLimit={-92}
           colorMap={colormap}

--- a/src/pages/dashboardContainer/helper/index.js
+++ b/src/pages/dashboardContainer/helper/index.js
@@ -1,3 +1,10 @@
+/**
+ * The below code is for demonstration purpose only.
+ * The transformation could be made inorder to consolidate data from many sources.
+ * Also, concrete dataFactory implementation, for example, ExampleDataFactory,
+ * could be formed during transformation.
+ */
+
 import { fetchAllFromFeaturesAPI } from '../../../services/api';
 
 export const extractStationCollections = (

--- a/src/pages/dashboardContainer/index.tsx
+++ b/src/pages/dashboardContainer/index.tsx
@@ -6,9 +6,7 @@ import { fetchAllFromSTACAPI } from '../../services/api';
 
 import { STACItem } from '../../dataModel';
 
-interface DataTree {
-  [key: string]: STACItem;
-}
+import { ExampleDataFactory } from '../../exampleDataFactory';
 
 export function DashboardContainer(): React.JSX.Element {
   // get the query params
@@ -28,7 +26,7 @@ export function DashboardContainer(): React.JSX.Element {
     searchParams.get('collection-id') || 'goes-ch4plume-v1'
   );
   const [loadingData, setLoadingData] = useState<boolean>(true);
-  const dataTree = useRef<DataTree | null>(null);
+  const dataFactory = useRef<ExampleDataFactory | null>(null);
 
   useEffect(() => {
     setLoadingData(true);
@@ -39,13 +37,12 @@ export function DashboardContainer(): React.JSX.Element {
         const collectionItemUrl: string = `${process.env.REACT_APP_STAC_API_URL}/collections/${collectionId}/items`;
         const data: STACItem[] = await fetchAllFromSTACAPI(collectionItemUrl);
 
-        const vizItemsDict: DataTree = {}; // visualization_items[string] = visualization_item
+        const exampleDataFactory: ExampleDataFactory = ExampleDataFactory.getInstance();
         const testSample: STACItem[] = data.slice(0, 10);
-        testSample.forEach((items) => {
-          vizItemsDict[items.id] = items;
+        testSample.forEach((item) => {
+          exampleDataFactory.addVizItem(item);
         });
-        dataTree.current = vizItemsDict;
-
+        dataFactory.current = exampleDataFactory;
         // NOTE: incase we need metadata and other added information,
         // add that to the STAC Item Property
 
@@ -61,7 +58,7 @@ export function DashboardContainer(): React.JSX.Element {
 
   return (
     <Dashboard
-      dataTree={dataTree}
+      dataFactory={dataFactory}
       zoomLocation={zoomLocation}
       zoomLevel={zoomLevel}
       setZoomLocation={setZoomLocation}


### PR DESCRIPTION
## Requirement:
The DataTree implementation as the props for the Dashboard was pretty vague. Instead of leaving it loose-ended to the implementation holder, created a DataFactory Abstract Base Class (ABC) - consisting of the bare minimum abstract methods needed for the dashboard. The dataTree implementation is encapsulated inside the concrete DataFactory implementation as per the use case of interface.

## What's changed:
1. Implemented dataFactory abstract class upon which the dashboard works.
2. Example concrete implementation of the dataFactory abc. Used later on the dashboard.
3. Remove the previous implementation of the dataTree, as it now goes inside the dataFactory encapsulation.