### PR TITLE
feat: Info card & map legend - Change the layout of the info card and add filterable map legend

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chartjs-plugin-annotation": "^3.0.1",
     "chartjs-plugin-zoom": "^2.0.1",
     "d3": "^7.9.0",
+    "fast-average-color": "^9.5.0",
     "luxon": "^3.5.0",
     "mapbox-gl": "^3.7.0",
     "mapboxgl-timeline": "^1.0.2",

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -41,5 +41,3 @@ export {
 } from './map/utils';
 
 // Add other component exports here as needed
-
-export { Dropdown } from './ui/dropdown';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@ export { VizItemTimeline } from './map/itemTimeline/index.tsx';
 export { MeasurementLayer } from './map/measurementLayer';
 export { MarkerFeature } from './map/mapMarker';
 export { MapZoom } from './map/mapZoom';
+export { MapLegend } from './map/mapLegend';
 
 // Map Layers
 export { VisualizationLayers } from './map/mapLayer';
@@ -17,7 +18,12 @@ export { VisualizationLayers } from './map/mapLayer';
 export { FilterByDate } from './method/filter';
 export { Search } from './method/search';
 
-export { VisualizationItemCard } from './ui/card';
+export { 
+  VisualizationItemCard,
+  StacItemInfoCard,
+  SamInfoCard,
+  BlankInfoCard
+ } from './ui/card';
 export { PersistentDrawerRight } from './ui/drawer';
 export { ColorBar } from './ui/colorBar';
 export { ConfigurableColorBar } from './ui/configurableColorBar';
@@ -31,6 +37,9 @@ export {
   addSourceLayerToMap,
   layerExists,
   sourceExists,
+  getMarkerColor
 } from './map/utils';
 
 // Add other component exports here as needed
+
+export { Dropdown } from './ui/dropdown';

--- a/src/components/map/mapLegend/index.css
+++ b/src/components/map/mapLegend/index.css
@@ -1,0 +1,57 @@
+.map-legend-container {
+    max-height: 500px;
+    overflow-y: auto;
+}
+
+.map-legend-title {
+    color: var(--main-blue);
+    font-weight: bold !important;
+    padding-left: 0.2rem;
+    text-align: left;
+}
+
+.clear-filter-button {
+    display: flex !important;
+    padding: 4px 8px !important;
+    transition: background-color 0.2s !important;
+}
+
+.map-legend-description {
+    color: rgba(0, 0, 0, 0.6);
+    margin-bottom: 8px !important;
+    font-size: 0.875rem !important;
+    padding-left: 0.2rem;
+}
+
+.marker-category-button {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: flex-start !important;
+    padding: 4px 8px !important;
+    border-radius: 4px !important;
+    text-align: left !important;
+    background-color: transparent !important;
+    cursor: pointer !important;
+    color: rgba(0, 0, 0, 0.6) !important;
+    transition: background-color 0.2s;
+}
+
+.marker-category-button:hover {
+    background-color: rgba(0, 0, 0, 0.04) !important;
+}
+
+.marker-category-button.selected {
+    background-color: rgba(19, 96, 189, 0.1) !important;
+}
+
+.marker-category-button.clicked {
+    background-color: rgba(19, 96, 189, 0.2) !important;
+}
+
+.marker-icon {
+    margin-right: 8px;
+}
+
+.marker-label {
+    white-space: nowrap;
+}

--- a/src/components/map/mapLegend/index.tsx
+++ b/src/components/map/mapLegend/index.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Typography,
+  IconButton,
+  Stack,
+  Tooltip,
+  ButtonBase,
+} from '@mui/material';
+import RoomIcon from '@mui/icons-material/Room';
+import ClearAllIcon from '@mui/icons-material/ClearAll';
+
+import { getMarkerColor } from '../utils';
+import { titleCase } from '../../../utils';
+
+import './index.css';
+
+
+interface MapLegendProps {
+  items: string[];
+  onSelect: (ids: string[]) => void;
+  title: string;
+  description: string;
+}
+
+export const MapLegend: React.FC<MapLegendProps> = ({ items, onSelect, title = '', description = '' }) => {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const COLUMN_THRESHOLD = 3;
+
+
+  const toggleSelect = (id: string) => {
+    const newSelected = selectedIds.includes(id)
+      ? selectedIds.filter((sid) => sid !== id)
+      : [...selectedIds, id];
+    setSelectedIds(newSelected);
+    onSelect(newSelected);
+  };
+
+  const clearFilter = () => {
+    setSelectedIds([]);
+    onSelect([]);
+  };
+
+  const isTwoColumn = items.length > COLUMN_THRESHOLD;
+
+  return (
+    <div>
+      <Box p={2} borderRadius={3} width="100%" bgcolor="background.paper" className="map-legend-container">
+        <Box display="flex" alignItems="left" flexDirection={'column'}>
+          <Box display="flex" justifyContent="space-between" alignItems="center">
+            <Typography className='map-legend-title'>{title}</Typography>
+            <Tooltip title="Clear Filter">
+              <ButtonBase className="clear-filter-button" onClick={clearFilter} sx={{ color: 'text.secondary' }}>
+                <Typography variant="body2" sx={{ mr: 1 }}>Clear filters </Typography><ClearAllIcon fontSize="medium" />
+              </ButtonBase>
+            </Tooltip>
+          </Box>
+          <Typography className='map-legend-description'>
+            {description}
+          </Typography>
+        </Box>
+
+        <Box
+          display="grid"
+          gridTemplateColumns={isTwoColumn ? '1fr 1fr' : '1fr'}
+          gap={1}
+          maxHeight={250}
+          overflow="auto"
+        >
+          {items.map((category) => {
+            const selected = selectedIds.includes(category);
+            return (
+              <ButtonBase
+                disableRipple
+                key={category}
+                onClick={() => toggleSelect(category)}
+                className={`marker-category-button ${selected ? 'selected' : ''}`}
+              >
+                <RoomIcon htmlColor={getMarkerColor(category)} sx={{ mr: 1 }} />
+                <Typography variant="body2" sx={{ whiteSpace: 'nowrap' }}>
+                  {titleCase(category)}
+                </Typography>
+              </ButtonBase>
+            );
+          })}
+        </Box>
+      </Box>
+    </div>
+  );
+};

--- a/src/components/map/utils/constants.js
+++ b/src/components/map/utils/constants.js
@@ -1,1 +1,15 @@
-export const ZOOM_LEVEL_MARGIN = 12;
+export const ZOOM_LEVEL_MARGIN = 8;
+
+export const PopularMapMarkerColors = [
+  '#00b7eb',
+  '#FF6347', // Tomato
+  '#1E90FF', // Dodger Blue
+  '#32CD32', // Lime Green
+  '#8A2BE2', // Blue Violet
+  '#FFA500', // Orange
+  '#FFD700', // Gold
+  '#00CED1', // Dark Turquoise
+  '#FF1493', // Deep Pink
+  '#6A5ACD', // Slate Blue
+  '#DC143C', // Crimson
+];

--- a/src/components/map/utils/index.js
+++ b/src/components/map/utils/index.js
@@ -1,3 +1,6 @@
+import { PopularMapMarkerColors } from "./constants";
+import { stringToNumberHash } from '../../../utils';
+
 /*
       Get id for source
 
@@ -129,3 +132,13 @@ export const addSourcePolygonToMap = (
     },
   });
 };
+
+
+/* Returns a color based on the category.
+   Uses a hash function to map the category to an index in the PopularMapMarkerColors array
+*/
+export function getMarkerColor(category) {
+  if (!category) return PopularMapMarkerColors[0]; // Default color if no category is provided
+  const colorIdx = stringToNumberHash(category) % PopularMapMarkerColors.length;
+  return PopularMapMarkerColors[colorIdx];
+}

--- a/src/components/ui/card/blankInfoCard.tsx
+++ b/src/components/ui/card/blankInfoCard.tsx
@@ -1,0 +1,40 @@
+import { Box, Typography } from '@mui/material';
+
+interface BlankInfoCardProps {
+  illustration?: string;
+  message?: string;
+}
+
+export function BlankInfoCard({ illustration, message }: BlankInfoCardProps) {
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        minHeight: '200px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        padding: 2,
+        color: 'text.secondary',
+        borderRadius: 2,
+        backgroundColor: 'background.paper',
+      }}
+    >
+      {illustration && (
+        <Box sx={{ maxWidth: '200px', mb: 2 }}>
+          <img
+            src={illustration}
+            alt="No SAMs selected"
+            style={{ width: '200px', height: '100%', padding: '8rem 4rem 0rem 4rem' }}
+          />
+        </Box>
+      )}
+      <Typography variant="body1" sx={{ marginBottom: 4, fontSize: '0.9rem' }}>
+        {message}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/components/ui/card/index.css
+++ b/src/components/ui/card/index.css
@@ -7,5 +7,5 @@
 }
 
 .card-download-link > div {
-  color: #0098d7;
+  color: rgb(16, 56, 126);
 }

--- a/src/components/ui/card/index.jsx
+++ b/src/components/ui/card/index.jsx
@@ -1,3 +1,4 @@
 export { VisualizationItemCard } from './legacyCard';
 export { StacItemInfoCard } from './stacItemInfoCard';
 export { SamInfoCard } from './samInfoCard';
+export { BlankInfoCard } from './blankInfoCard';

--- a/src/components/ui/card/samInfoCard.tsx
+++ b/src/components/ui/card/samInfoCard.tsx
@@ -8,6 +8,8 @@ import {
   CaptionValue,
 } from './stacItemInfoCard';
 
+import { TruncatedCopyText } from '../truncatedText';
+
 interface SamInfoCardProps extends StacItemInfoCardProps {
   hoveredVizid: string;
   cardRef?: React.MutableRefObject<HTMLDivElement | null> | undefined;
@@ -32,6 +34,8 @@ export const SamInfoCard = ({
   const [targetName, setTargetName] = useState<string>('');
   const [targetType, setTargetType] = useState<string>('');
   const [targetAltitude, setTargetAltitude] = useState<string>('');
+  const [minValue, setMinValue] = useState<number | string>('N/A');
+  const [maxValue, setMaxValue] = useState<number | string>('N/A');
   const [hov, setHov] = useState<boolean>(false);
 
   useEffect(() => {
@@ -45,6 +49,16 @@ export const SamInfoCard = ({
     let targetName: string = stacItem.properties.target_name;
     let targetType: string = stacItem.properties.target_type;
     let targetAltitude: string = stacItem.properties.target_altitude;
+    let minValue: number | string = 'N/A';
+    let maxValue: number | string = 'N/A';
+
+
+    if (assets) {
+      minValue =
+        stacItem.assets?.[assets]?.['raster:bands']?.[0]?.statistics?.minimum ?? 'N/A';
+      maxValue =
+        stacItem.assets?.[assets]?.['raster:bands']?.[0]?.statistics?.maximum ?? 'N/A';
+    }
 
     setStartDatetime(startDatetime);
     setEndDatetime(endDatetime);
@@ -52,6 +66,9 @@ export const SamInfoCard = ({
     setTargetName(targetName);
     setTargetType(targetType);
     setTargetAltitude(targetAltitude);
+    setMinValue(minValue);
+    setMaxValue(maxValue);
+
   }, [stacItem]);
 
   return (
@@ -70,36 +87,54 @@ export const SamInfoCard = ({
         <>
           <Box sx={{ marginTop: '20px' }}>
             {/* Target Group */}
-            <Typography variant="body2" sx={{ mb: 0.5, color: 'var(--main-blue)' }}>Target Details</Typography>
-            <Grid container spacing={1}>
-              <Grid item xs={12} sm={6}>
-                <CaptionValue caption='Target Id'>{targetId}</CaptionValue>
-              </Grid>
-              <Grid item xs={12} sm={6}>
-                <CaptionValue caption='Target Type'>{targetType}</CaptionValue>
-              </Grid>
-              <Grid item xs={12} sm={6}>
-                <CaptionValue caption='Target Name'>{targetName}</CaptionValue>
-              </Grid>
-              <Grid item xs={12} sm={6}>
-                <CaptionValue caption='Target Altitude'>{targetAltitude}</CaptionValue>
-              </Grid>
-            </Grid>
+            <Typography variant="body2" sx={{ mb: 0.5, color: 'var(--main-blue)' }}>SAM Details</Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2, width: '100%' }}>
+              {/* Left Group: 75% width, column layout */}
+              <Box sx={{ flex: 3, display: 'flex', flexDirection: 'column', gap: 1 }}>
+                <CaptionValue caption="SAM ID">{targetId}</CaptionValue>
+                <CaptionValue caption="SAM Name">
+                  <TruncatedCopyText text={targetName} maxLength={35} />
+                </CaptionValue>
+              </Box>
+
+              {/* Right Group: 25% width, column layout */}
+              <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+                <CaptionValue caption="SAM Type">{targetType}</CaptionValue>
+                <CaptionValue caption="SAM Altitude">{targetAltitude}</CaptionValue>
+              </Box>
+            </Box>
 
             {/* Visualization Group */}
             <Typography variant="body2" sx={{ mt: 3, mb: 0.5, color: 'var(--main-blue)' }}>Visualization Details</Typography>
-            <Grid container spacing={2}>
-              <Grid item xs={12} sm={6}>
-                <CaptionValue caption='Start Time'>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0, width: '100%' }}>
+              {/* Acquisition Time */}
+              <Box sx={{ flex: 1 }}>
+                <CaptionValue caption="Acquisition Time">
                   {moment.utc(startDatetime).format('MM/DD/YYYY, HH:mm:ss') + ' UTC'}
                 </CaptionValue>
-              </Grid>
-              <Grid item xs={12} sm={6}>
-                <CaptionValue caption='End Time'>
-                  {moment.utc(endDatetime).format('MM/DD/YYYY, HH:mm:ss') + ' UTC'}
-                </CaptionValue>
-              </Grid>
-            </Grid>
+              </Box>
+
+              {/* Min and Max Values */}
+              <Box
+                sx={{
+                  flex: 1,
+                  display: 'flex',
+                  flexDirection: 'row',
+                  gap: 2,
+                }}
+              >
+                <Box sx={{ flex: 1 }}>
+                  <CaptionValue caption="Min Value">
+                    {Number(minValue).toFixed(3)}
+                  </CaptionValue>
+                </Box>
+                <Box sx={{ flex: 1 }}>
+                  <CaptionValue caption="Max Value">
+                    {Number(maxValue).toFixed(3)}
+                  </CaptionValue>
+                </Box>
+              </Box>
+            </Box>
           </Box>
 
         </>

--- a/src/components/ui/card/samInfoCard.tsx
+++ b/src/components/ui/card/samInfoCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import moment from 'moment';
+import { Box, CardContent, CardMedia, Typography, Grid } from '@mui/material';
 import {
   StacItemInfoCard,
   StacItemInfoCardProps,
@@ -7,7 +8,10 @@ import {
   CaptionValue,
 } from './stacItemInfoCard';
 
-interface SamInfoCardProps extends StacItemInfoCardProps {}
+interface SamInfoCardProps extends StacItemInfoCardProps {
+  hoveredVizid: string;
+  cardRef?: React.MutableRefObject<HTMLDivElement | null> | undefined;
+}
 
 export const SamInfoCard = ({
   stacItem,
@@ -15,6 +19,12 @@ export const SamInfoCard = ({
   onHover,
   hovered,
   clicked,
+  hoveredVizid,
+  VMAX,
+  VMIN,
+  colorMap,
+  assets,
+  cardRef,
 }: SamInfoCardProps): JSX.Element => {
   const [startDatetime, setStartDatetime] = useState<string>('');
   const [endDatetime, setEndDatetime] = useState<string>('');
@@ -22,6 +32,11 @@ export const SamInfoCard = ({
   const [targetName, setTargetName] = useState<string>('');
   const [targetType, setTargetType] = useState<string>('');
   const [targetAltitude, setTargetAltitude] = useState<string>('');
+  const [hov, setHov] = useState<boolean>(false);
+
+  useEffect(() => {
+    setHov(stacItem.id === hoveredVizid);
+  }, [hoveredVizid, stacItem.id]);
 
   useEffect(() => {
     let startDatetime: string = stacItem.properties.start_datetime;
@@ -40,43 +55,55 @@ export const SamInfoCard = ({
   }, [stacItem]);
 
   return (
-    <StacItemInfoCard
-      stacItem={stacItem}
-      onClick={onClick}
-      onHover={onHover}
-      hovered={hovered}
-      clicked={clicked}
-    >
-      <>
-        <HorizontalLayout>
-          <CaptionValue caption='Target Id' value={targetId} className='' />
-          <CaptionValue caption='Target Type' value={targetType} className='' />
-        </HorizontalLayout>
-        <HorizontalLayout>
-          <CaptionValue caption='Target Name' value={targetName} className='' />
-          <CaptionValue
-            caption='Target Altitude'
-            value={targetAltitude}
-            className=''
-          />
-        </HorizontalLayout>
-        <HorizontalLayout>
-          <CaptionValue
-            caption='Visualization Start Time '
-            value={
-              moment.utc(startDatetime).format('MM/DD/YYYY, HH:mm:ss') + ' UTC'
-            }
-            className=''
-          />
-          <CaptionValue
-            caption='Visualization End Time '
-            value={
-              moment.utc(endDatetime).format('MM/DD/YYYY, HH:mm:ss') + ' UTC'
-            }
-            className=''
-          />
-        </HorizontalLayout>
-      </>
-    </StacItemInfoCard>
+    <div ref={cardRef}>
+      <StacItemInfoCard
+        stacItem={stacItem}
+        onClick={onClick}
+        onHover={onHover}
+        hovered={hov}
+        clicked={clicked}
+        VMAX={VMAX}
+        VMIN={VMIN}
+        colorMap={colorMap}
+        assets={assets}
+      >
+        <>
+          <Box sx={{ marginTop: '20px' }}>
+            {/* Target Group */}
+            <Typography variant="body2" sx={{ mb: 0.5, color: 'var(--main-blue)' }}>Target Details</Typography>
+            <Grid container spacing={1}>
+              <Grid item xs={12} sm={6}>
+                <CaptionValue caption='Target Id'>{targetId}</CaptionValue>
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <CaptionValue caption='Target Type'>{targetType}</CaptionValue>
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <CaptionValue caption='Target Name'>{targetName}</CaptionValue>
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <CaptionValue caption='Target Altitude'>{targetAltitude}</CaptionValue>
+              </Grid>
+            </Grid>
+
+            {/* Visualization Group */}
+            <Typography variant="body2" sx={{ mt: 3, mb: 0.5, color: 'var(--main-blue)' }}>Visualization Details</Typography>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={6}>
+                <CaptionValue caption='Start Time'>
+                  {moment.utc(startDatetime).format('MM/DD/YYYY, HH:mm:ss') + ' UTC'}
+                </CaptionValue>
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <CaptionValue caption='End Time'>
+                  {moment.utc(endDatetime).format('MM/DD/YYYY, HH:mm:ss') + ' UTC'}
+                </CaptionValue>
+              </Grid>
+            </Grid>
+          </Box>
+
+        </>
+      </StacItemInfoCard>
+    </div>
   );
 };

--- a/src/components/ui/card/stacItemInfoCard.tsx
+++ b/src/components/ui/card/stacItemInfoCard.tsx
@@ -31,13 +31,14 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const HighlightableCard = styled(Card) <CardProps>`
+  border-radius: 12px !important;
   transition: border 0.3s ease;
   &:hover {
     border: 1px solid rgb(59, 130, 246);
   }
   border: ${(props) =>
     //eslint-disable-next-line prettier/prettier
-    props.$isHovered ? '1px solid rgb(59, 130, 246)' : '1px solid transparent'};
+    props.$isHovered ? '1px solid rgb(59, 130, 246)' : '1px solid rgba(156, 166, 180, 0.25)'};
 `;
 
 interface CaptionValueInterface {
@@ -48,7 +49,7 @@ interface CaptionValueInterface {
 
 export const CaptionValue = ({
   caption,
-  className='',
+  className = '',
   children,
 }: CaptionValueInterface): JSX.Element => {
   return (
@@ -158,40 +159,51 @@ export function StacItemInfoCard({
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', flex: '1 0 auto' }}>
         <CardContent sx={{ flex: '1 0 auto' }}>
-          <Box sx={{ display: 'flex', flexDirection: 'row', flex: '1 0 auto', alignItems: 'left', justifyContent: 'space-between', marginBottom: '10px' }}>
+          <Box sx={{ display: 'flex', flexDirection: 'row', flex: '1 0 auto', alignItems: 'top', justifyContent: 'space-between', marginBottom: '10px' }}>
             <div>
+              <Typography variant="body2" sx={{ mb: 0.5, color: 'var(--main-blue)' }}>STAC Details</Typography>
               <HorizontalLayout>
                 <CaptionValue
                   caption='Visualization Item ID'
                   className=''
-                ><TruncatedCopyText text={id} /></CaptionValue>
+                ><TruncatedCopyText text={id} maxLength={25} /></CaptionValue>
               </HorizontalLayout>
-              <HorizontalLayout>
+              {/* <HorizontalLayout>
                 <CaptionValue
                   caption='STAC Collection ID'
                   className=''
                 ><TruncatedCopyText text={collection} /></CaptionValue>
-              </HorizontalLayout>
+              </HorizontalLayout> */}
               <HorizontalLayout>
                 <CaptionValue
-                  caption='Release Location (Approximate)'
+                  caption='Center Coordinates'
                   className=''
                 >
-                  <div style={{ display: 'flex', gap: '1rem' }}>
-                    <div>Lat: {Number(lat).toFixed(3)}</div>
-                    <div>Lon: {Number(lon).toFixed(3)}</div>
+                  <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <div>Latitude: {Number(lat).toFixed(3)}</div>
+                    <div>Longitude: {Number(lon).toFixed(3)}</div>
                   </div>
                 </CaptionValue>
 
               </HorizontalLayout>
             </div>
-            <div style={{ display: 'flex', flexDirection: 'column', width: '50%', justifyContent: 'center' }}>
+            <div style={{
+              display: 'flex',
+              flexDirection: 'column',
+              width: '40%',
+              maxWidth: '200px',
+              justifyContent: 'center',
+              borderRadius: '16px',
+            }}
+            >
               <CardMedia
                 component='img'
                 sx={{
                   objectFit: 'contain',
-                  maxWidth: '200px',
+                  width: '100%',
+                  height: 'auto',
                   padding: '10px',
+                  borderRadius: '8px',
                   imageRendering: 'pixelated',
                   backgroundColor: imgBgColor
                 }}
@@ -207,7 +219,7 @@ export function StacItemInfoCard({
                 >
                   <Typography variant='caption' component='div'>
                     <div style={{ display: 'flex', justifyContent: 'center' }}>
-                      Download the Tiff File <DownloadIcon fontSize='small' />
+                      Download the TIFF File <DownloadIcon fontSize='small' />
                     </div>
                   </Typography>
                 </a>

--- a/src/components/ui/card/stacItemInfoCard.tsx
+++ b/src/components/ui/card/stacItemInfoCard.tsx
@@ -7,10 +7,15 @@ import Typography from '@mui/material/Typography';
 import styled from 'styled-components';
 import Divider from '@mui/material/Divider';
 import DownloadIcon from '@mui/icons-material/Download';
+import { FastAverageColor } from 'fast-average-color';
+
+import { getBackgroundColorFromImage } from '../../../utils'
+import { TruncatedCopyText } from '../truncatedText';
 
 import { STACItem } from '../../../dataModel';
 
 import './index.css';
+import { get } from 'http';
 
 export const HorizontalLayout = styled.div`
   width: 100%;
@@ -25,37 +30,33 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   $isHovered?: boolean;
 }
 
-const HighlightableCard = styled(Card)<CardProps>`
+const HighlightableCard = styled(Card) <CardProps>`
   transition: border 0.3s ease;
   &:hover {
-    border: 1px solid blue;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+    border: 1px solid rgb(59, 130, 246);
   }
   border: ${(props) =>
     //eslint-disable-next-line prettier/prettier
-    props.$isHovered ? '1px solid blue' : '1px solid transparent'};
-  box-shadow: ${(props) =>
-    //eslint-disable-next-line prettier/prettier
-    props.$isHovered ? '0 4px 20px rgba(0, 0, 0, 0.2)' : 'none'};
+    props.$isHovered ? '1px solid rgb(59, 130, 246)' : '1px solid transparent'};
 `;
 
 interface CaptionValueInterface {
   caption: string;
-  value: number | string;
-  className: string;
+  className?: string;
+  children?: React.ReactNode;
 }
 
 export const CaptionValue = ({
   caption,
-  value,
-  className,
+  className='',
+  children,
 }: CaptionValueInterface): JSX.Element => {
   return (
     <div className={className}>
       <Typography
         variant='caption'
         component='div'
-        sx={{ color: 'text.primary' }}
+        sx={{ color: 'var(--main-blue)' }}
       >
         {caption}
       </Typography>
@@ -64,7 +65,7 @@ export const CaptionValue = ({
         component='div'
         sx={{ color: 'text.secondary' }}
       >
-        {value}
+        {children}
       </Typography>
     </div>
   );
@@ -77,6 +78,10 @@ export interface StacItemInfoCardProps {
   hovered: boolean;
   clicked: boolean;
   children?: JSX.Element;
+  VMIN?: number;
+  VMAX?: number;
+  colorMap?: string;
+  assets?: string;
 }
 
 export function StacItemInfoCard({
@@ -86,11 +91,16 @@ export function StacItemInfoCard({
   onClick,
   onHover,
   children,
+  VMIN,
+  VMAX,
+  colorMap,
+  assets,
 }: StacItemInfoCardProps): JSX.Element {
   const [isHovered, setIsHovered] = useState<boolean>(hovered || false);
   const [id, setId] = useState<string>('');
   const [collection, setCollection] = useState<string>('');
   const [thumbnailUrl, setThumbnailUrl] = useState<string>('');
+  const [imgBgColor, setImgBgColor] = useState<string>('#333');
   const [lon, setLon] = useState<number | undefined>();
   const [lat, setLat] = useState<number | undefined>();
   const [tiffUrl, setTiffUrl] = useState<string>('');
@@ -118,88 +128,92 @@ export function StacItemInfoCard({
     setLon(coordinates[0]);
     setLat(coordinates[1]);
 
-    let VMIN = 0;
-    let VMAX = 0.4;
-    let colorMap = 'plasma';
-    const thumbnailUrl: string = `${process.env.REACT_APP_RASTER_API_URL}/collections/${collection}/items/${id}/preview.png?assets=rad&rescale=${VMIN}%2C${VMAX}&colormap_name=${colorMap}`;
+    let lvmin = VMIN || 400;
+    let lvmax = VMAX || 420;
+    let lcolormap = colorMap || 'plasma';
+    let lassets = assets || 'rad';
+    const thumbnailUrl: string = `${process.env.REACT_APP_RASTER_API_URL}/collections/${collection}/items/${id}/preview.png?assets=${lassets}&rescale=${lvmin}%2C${lvmax}&colormap_name=${lcolormap}`;
     setThumbnailUrl(thumbnailUrl);
+
+    getBackgroundColorFromImage(thumbnailUrl, '#444', '#eee').then(color => {
+      setImgBgColor(color);
+    });
 
     let firstAssetKey = Object.keys(stacItem.assets)[0];
     let firstAsset = stacItem.assets[firstAssetKey];
     setTiffUrl(firstAsset.href);
-  }, [stacItem]);
+  }, [stacItem, VMIN, VMAX, colorMap, assets]);
+
+  useEffect(() => {
+    setIsHovered(hovered);
+  }, [hovered]);
 
   return (
     <HighlightableCard
-      sx={{ display: 'flex', flex: '0 0 auto', margin: '15px' }}
+      sx={{ display: 'flex', flex: '0 0 auto', margin: '15px', padding: '10px' }}
       onClick={handleCardClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       $isHovered={isHovered}
     >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <CardMedia
-          component='img'
-          height='100'
-          sx={{
-            padding: '1em',
-            objectFit: 'contain',
-            minWidth: '50px',
-            imageRendering: 'pixelated',
-          }}
-          image={thumbnailUrl}
-          alt='Visualization Item image'
-        />
-      </div>
-
-      <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', flex: '1 0 auto' }}>
         <CardContent sx={{ flex: '1 0 auto' }}>
-          <HorizontalLayout>
-            <CaptionValue
-              caption='Visualization Item ID'
-              value={id}
-              className=''
-            />
-          </HorizontalLayout>
-          <HorizontalLayout>
-            <CaptionValue
-              caption='STAC Collection ID'
-              value={collection}
-              className=''
-            />
-          </HorizontalLayout>
-          <HorizontalLayout>
-            <CaptionValue
-              className='card-plume'
-              caption='Approximate Release Longitude'
-              value={Number(lon).toFixed(3)}
-            />
-            <CaptionValue
-              className='card-plume'
-              caption='Approximate Release Latitude'
-              value={Number(lat).toFixed(3)}
-            />
-          </HorizontalLayout>
-          <HorizontalLayout>
-            <a
-              href={tiffUrl}
-              target='_blank'
-              rel='noreferrer'
-              className='card-download-link'
-            >
-              <Typography variant='caption' component='div'>
-                <div style={{ display: 'flex', justifyContent: 'center' }}>
-                  Download the Tiff File <DownloadIcon fontSize='small' />
-                </div>
-              </Typography>
-            </a>
-          </HorizontalLayout>
+          <Box sx={{ display: 'flex', flexDirection: 'row', flex: '1 0 auto', alignItems: 'left', justifyContent: 'space-between', marginBottom: '10px' }}>
+            <div>
+              <HorizontalLayout>
+                <CaptionValue
+                  caption='Visualization Item ID'
+                  className=''
+                ><TruncatedCopyText text={id} /></CaptionValue>
+              </HorizontalLayout>
+              <HorizontalLayout>
+                <CaptionValue
+                  caption='STAC Collection ID'
+                  className=''
+                ><TruncatedCopyText text={collection} /></CaptionValue>
+              </HorizontalLayout>
+              <HorizontalLayout>
+                <CaptionValue
+                  caption='Release Location (Approximate)'
+                  className=''
+                >
+                  <div style={{ display: 'flex', gap: '1rem' }}>
+                    <div>Lat: {Number(lat).toFixed(3)}</div>
+                    <div>Lon: {Number(lon).toFixed(3)}</div>
+                  </div>
+                </CaptionValue>
+
+              </HorizontalLayout>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', width: '50%', justifyContent: 'center' }}>
+              <CardMedia
+                component='img'
+                sx={{
+                  objectFit: 'contain',
+                  maxWidth: '200px',
+                  padding: '10px',
+                  imageRendering: 'pixelated',
+                  backgroundColor: imgBgColor
+                }}
+                image={thumbnailUrl}
+                alt='Visualization Item image'
+              />
+              <HorizontalLayout>
+                <a
+                  href={tiffUrl}
+                  target='_blank'
+                  rel='noreferrer'
+                  className='card-download-link'
+                >
+                  <Typography variant='caption' component='div'>
+                    <div style={{ display: 'flex', justifyContent: 'center' }}>
+                      Download the Tiff File <DownloadIcon fontSize='small' />
+                    </div>
+                  </Typography>
+                </a>
+              </HorizontalLayout>
+            </div>
+          </Box>
           {children && (
             <>
               <Divider></Divider>

--- a/src/components/ui/drawer/index.css
+++ b/src/components/ui/drawer/index.css
@@ -1,7 +1,7 @@
 .drawer-head {
   color: var(--main-blue);
   text-align: center;
-  margin: 0 0.5rem;
+  margin: 0 0.75rem -1rem 0.75rem;
 }
 
 .drawer-head-content {

--- a/src/components/ui/drawer/index.css
+++ b/src/components/ui/drawer/index.css
@@ -1,8 +1,7 @@
 .drawer-head {
   color: var(--main-blue);
   text-align: center;
-  border-bottom: 2px solid var(--main-blue);
-  margin: 0 0.9rem;
+  margin: 0 0.5rem;
 }
 
 .drawer-head-content {

--- a/src/components/ui/drawer/index.jsx
+++ b/src/components/ui/drawer/index.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { styled as styledmui } from '@mui/material/styles';
 import styled from 'styled-components';
 import Box from '@mui/material/Box';
@@ -63,7 +64,18 @@ const HorizontalLayout = styled.div`
 //   body: React.ReactNode;
 // }
 
-export function PersistentDrawerRight({ open, header, body }) {
+export function PersistentDrawerRight({ open, header, body, cardRef }) {
+  // optional: cardRef is the ref to the actual card/div available in the body.
+  // when hoverover the cardRef. it will scroll to the view.
+  useEffect(() => {
+    if (cardRef && cardRef.current) {
+      cardRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cardRef.current]);
   return (
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />
@@ -73,15 +85,14 @@ export function PersistentDrawerRight({ open, header, body }) {
       <Drawer
         sx={{
           width: drawerWidth,
-          marginRight: '5px',
-          marginTop: '5px',
           flexShrink: 0,
           '& .MuiDrawer-paper': {
             width: drawerWidth,
             marginRight: '5px',
             marginTop: '5px',
-            height: 'calc(100vh - var(--colorbar-height) - 3.5%)', //colobar is up 3% from bottom
-            borderRadius: '3px',
+            maxHeight: 'calc(100vh - 10px)', //colobar is up 3% from bottom
+            height: 'auto',
+            borderRadius: '12px',
           },
         }}
         variant='persistent'

--- a/src/components/ui/truncatedText/index.tsx
+++ b/src/components/ui/truncatedText/index.tsx
@@ -1,9 +1,14 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { IconButton, Tooltip, Box, Typography } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 export function TruncatedCopyText({ text, maxLength = 20 }: { text: string; maxLength?: number }) {
   const [copied, setCopied] = useState(false);
+  const [truncated, setTruncated] = useState(false);
+
+  useEffect(() => {
+    setTruncated(text.length > maxLength);
+  }, [text, maxLength]);
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(text);
@@ -18,8 +23,8 @@ export function TruncatedCopyText({ text, maxLength = 20 }: { text: string; maxL
           sx={{
             whiteSpace: 'nowrap',
             overflow: 'hidden',
-            maskImage: 'linear-gradient(to right, black 70%, transparent)',
-            WebkitMaskImage: 'linear-gradient(to right, black 70%, transparent)',
+            maskImage: truncated ? 'linear-gradient(to right, black 70%, transparent)' : 'none',
+            WebkitMaskImage: truncated ? 'linear-gradient(to right, black 70%, transparent)' : 'none',
             mr: 1,
           }}
         >
@@ -27,8 +32,17 @@ export function TruncatedCopyText({ text, maxLength = 20 }: { text: string; maxL
         </Box>
       </Tooltip>
       <Tooltip title={copied ? 'Copied' : 'Copy'}>
-        <IconButton size="small" onClick={handleCopy}>
-          <ContentCopyIcon fontSize="small" />
+        <IconButton
+          size="small"
+          onClick={handleCopy}
+        >
+          <ContentCopyIcon
+            fontSize="small"
+            sx={{
+              width: '18px',
+              height: '18px',
+            }}
+          />
         </IconButton>
       </Tooltip>
     </Box>

--- a/src/components/ui/truncatedText/index.tsx
+++ b/src/components/ui/truncatedText/index.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { IconButton, Tooltip, Box, Typography } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+
+export function TruncatedCopyText({ text, maxLength = 20 }: { text: string; maxLength?: number }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', maxWidth: `${maxLength * 1}ch` }}>
+      <Tooltip title={text}>
+        <Box
+          sx={{
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            maskImage: 'linear-gradient(to right, black 70%, transparent)',
+            WebkitMaskImage: 'linear-gradient(to right, black 70%, transparent)',
+            mr: 1,
+          }}
+        >
+          <Typography variant="body2" component="span" sx={{ color: 'text.secondary' }}>{text}</Typography>
+        </Box>
+      </Tooltip>
+      <Tooltip title={copied ? 'Copied' : 'Copy'}>
+        <IconButton size="small" onClick={handleCopy}>
+          <ContentCopyIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import { Typography } from '@mui/material';
@@ -83,6 +83,9 @@ export function Dashboard({
 
   // states for components/controls
   const [openDrawer, setOpenDrawer] = useState<boolean>(false);
+
+  // ref. to scroll to the hovered card within the drawer
+  const cardRef = useRef<HTMLDivElement>(null);
 
   // handler functions
   const handleSelectedVizItem = (vizItemId: string) => {
@@ -215,6 +218,7 @@ export function Dashboard({
         </MainMap>
         <PersistentDrawerRight
           open={openDrawer}
+          cardRef={cardRef}
           header={
             <>
               <Typography

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,62 @@
+import { FastAverageColor } from 'fast-average-color';
+
+export function stringToNumberHash(str) {
+  let hash = 0;
+  // If the string is empty, return 0
+  if (str.length === 0) {
+    return hash;
+  }
+
+  // Iterate over each character in the string
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i); // Get the Unicode value of the character
+    hash = ((hash << 5) - hash) + char; // A common hash algorithm (hash * 31 + char)
+    hash |= 0; // Convert to a 32-bit integer (effectively a signed 32-bit integer)
+  }
+
+  // Return the absolute value to ensure it's always positive,
+  // or you can leave it signed if your use case allows negative numbers.
+  // Using Math.abs() to ensure it's positive, as colors or indices are usually positive.
+  return Math.abs(hash);
+}
+
+
+/*
+  Converts a string to title case, capitalizing the first letter of each word
+*/
+export function titleCase(text) {
+  if (!text) {
+    return ''; // Handle empty strings gracefully
+  }
+
+  // Convert the string to lowercase, then split it into an array of words
+  const words = text.toLowerCase().split(' ');
+
+  // Map over the array, capitalizing the first letter of each word
+  const titleCasedWords = words.map((word) => {
+    return word.charAt(0).toUpperCase() + word.slice(1);
+  });
+
+  // Join the words back into a single string with spaces
+  return titleCasedWords.join(' ');
+}
+
+
+/* Get the background color based on the average color of an image.
+  If the image is dark, return a light background color, otherwise return a dark background color.
+*/
+export async function getBackgroundColorFromImage(
+  imageUrl,
+  darkBgColor = '#111',
+  lightBgColor = '#eee',
+) {
+  if (!imageUrl) return lightBgColor;
+  const fac = new FastAverageColor();
+
+  try {
+    const color = await fac.getColorAsync(imageUrl, { mode: 'speed' });
+    return color.isDark ? lightBgColor : darkBgColor;
+  } catch (error) {
+    return lightBgColor;
+  }
+}


### PR DESCRIPTION
### Requirements

1. Improve the layout of the `StacItem` / `VizItem` info card for better readability.  
2. The TIFF image in the info card was too small and difficult to see.
3. Add the legend for map markers and ability to filter them.

---

### Changes

1. Updated the info card layout to a cleaner and more modern design.  
2. Repositioned the TIFF image and added a background color based on the color map for better visibility  
   - Dark background for light TIFF images, and vice versa.  
3. Created a new `BlankInfoCard` component that displays an illustration and a prompt when no visualization item is selected.  
4. Added a `TruncatedCopyText` component to show truncated text with a copy-to-clipboard button.
5. Added MapLegend component to display marker legends and filter them by clicking.

